### PR TITLE
TLCALIPER-118 - Bulk event creation

### DIFF
--- a/src/reconcile/caliperEventTsv.sh
+++ b/src/reconcile/caliperEventTsv.sh
@@ -4,6 +4,7 @@ UNSORTED_DATA="unsorted_${$}.tsv"
 
 # Send input through stdin or give a filename as an argument
 
-jq -r '[.eventTime[:19]+"Z", .actor.name, .object["@id"], .generated.value//"0"]|@tsv' ${1:--} > ${UNSORTED_DATA}
-sort -u ${UNSORTED_DATA} | sed 's/%40/@/g'
+jq -r '[.generated.attempt.endedAtTime[:19]+"Z", .actor.name, .object["@id"], .generated.value//"0"]|@tsv' ${1:--} > ${UNSORTED_DATA}
+
+sort ${UNSORTED_DATA} | sed 's/%40/@/g'
 rm ${UNSORTED_DATA}

--- a/src/reconcile/jsonlSort.sh
+++ b/src/reconcile/jsonlSort.sh
@@ -1,11 +1,12 @@
 #!/bin/sh --
 
-# Execute with an argument containing the name of the property to be
-# used for sorting.
+# Execute with arguments:
+# 1. (Required) Name of the property to be used for sorting.
+# 2. (Optional) Name of the input file to be sorted. Default: stdin
 
-# Improved according to a suggestion from @pkoppstein in response to my
-# support issue:
+# Improved according to a suggestion from @pkoppstein
+# in response to support issue:
 # https://github.com/stedolan/jq/issues/1447#issuecomment-314918635
 
-jq --slurp --compact-output 'sort_by(.'${1}')[]'
+jq --slurp --compact-output --sort-keys 'sort_by(.'${1}')[]' ${2:--}
 

--- a/src/reconcile/jsonlSort.sh
+++ b/src/reconcile/jsonlSort.sh
@@ -1,0 +1,11 @@
+#!/bin/sh --
+
+# Execute with an argument containing the name of the property to be
+# used for sorting.
+
+# Improved according to a suggestion from @pkoppstein in response to my
+# support issue:
+# https://github.com/stedolan/jq/issues/1447#issuecomment-314918635
+
+jq --slurp --compact-output 'sort_by(.'${1}')[]'
+

--- a/src/reconcile/pr_caliper_event_template.jq
+++ b/src/reconcile/pr_caliper_event_template.jq
@@ -34,10 +34,10 @@
       "startedAtTime": .startTime,
     },
     "extensions": {
-      "correctAnswer": .correctAnswer,
-      "isStudentAnswerCorrect": .isAnswerCorrect,
+      "correctAnswer": "\(.correctAnswer)",
+      "isStudentAnswerCorrect": "\(.isAnswerCorrect)",
     },
-    "value": .actorAnswer,
+    "value": "\(.actorAnswer)",
   },
   "group": {
     "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",

--- a/src/reconcile/pr_caliper_event_template.jq
+++ b/src/reconcile/pr_caliper_event_template.jq
@@ -1,0 +1,60 @@
+{
+  "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",
+  "@type": "http://purl.imsglobal.org/caliper/v1/AssessmentItemEvent",
+  "action": ("http://purl.imsglobal.org/vocab/caliper/v1/action#" + .action),
+  "actor": {
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",
+    "@id": ("https://mcommunity.umich.edu/#profile:" + .actorUniqname),
+    "@type": "http://purl.imsglobal.org/caliper/v1/lis/Person",
+    "name": .actorUniqname,
+  },
+  "edApp": {
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",
+    "@id": "https://problemroulette.lsa.umich.edu/",
+    "@type": "http://purl.imsglobal.org/caliper/v1/SoftwareApplication",
+  },
+  "eventTime": .endTime,
+  "extensions": {
+    "edu.umich": {
+      "description": "Event regenerated from application data, not live interaction.",
+      "regeneratedTime": (now|todateiso8601),
+    },
+  },
+  "generated": {
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",
+    "@id": (.problemUrl + "/response"),
+    "@type": "http://purl.imsglobal.org/caliper/v1/MultipleChoiceResponse",
+    "attempt": {
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",
+      "@id": (.problemUrl + "/attempt"),
+      "@type": "http://purl.imsglobal.org/caliper/v1/Attempt",
+      "count": .attemptCountNum,
+      "duration": .durationSeconds,
+      "endedAtTime": .endTime,
+      "startedAtTime": .startTime,
+    },
+    "extensions": {
+      "correctAnswer": .correctAnswer,
+      "isStudentAnswerCorrect": .isAnswerCorrect,
+    },
+    "value": .actorAnswer,
+  },
+  "group": {
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",
+    "@id": ("https://problemroulette.lsa.umich.edu/courses/" + (.courseIdNum|tostring)),
+    "@type": "http://purl.imsglobal.org/caliper/v1/lis/CourseOffering",
+    "name": .courseName,
+  },
+  "object": {
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",
+    "@id": .problemUrl,
+    "@type": "http://purl.imsglobal.org/caliper/v1/AssessmentItem",
+    "isPartOf": {
+      "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",
+      "@id": ("https://problemroulette.lsa.umich.edu/courses/" + (.courseIdNum|tostring) + "/topics/" + (.topicIdNum|tostring)),
+      "@type": "http://purl.imsglobal.org/caliper/v1/Assessment",
+      "name": .topicName,
+    },
+    "name": .problemName,
+  },
+}

--- a/src/reconcile/pr_caliper_event_template.jq
+++ b/src/reconcile/pr_caliper_event_template.jq
@@ -1,10 +1,10 @@
 {
   "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",
   "@type": "http://purl.imsglobal.org/caliper/v1/AssessmentItemEvent",
-  "action": ("http://purl.imsglobal.org/vocab/caliper/v1/action#" + .action),
+  "action": "http://purl.imsglobal.org/vocab/caliper/v1/action#\(.action)",
   "actor": {
     "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",
-    "@id": ("https://mcommunity.umich.edu/#profile:" + .actorUniqname),
+    "@id": "https://mcommunity.umich.edu/#profile:\(.actorUniqname)",
     "@type": "http://purl.imsglobal.org/caliper/v1/lis/Person",
     "name": .actorUniqname,
   },
@@ -22,11 +22,11 @@
   },
   "generated": {
     "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",
-    "@id": (.problemUrl + "/response"),
+    "@id": "\(.problemUrl)/response",
     "@type": "http://purl.imsglobal.org/caliper/v1/MultipleChoiceResponse",
     "attempt": {
       "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",
-      "@id": (.problemUrl + "/attempt"),
+      "@id": "\(.problemUrl)/attempt",
       "@type": "http://purl.imsglobal.org/caliper/v1/Attempt",
       "count": .attemptCountNum,
       "duration": .durationSeconds,
@@ -41,7 +41,7 @@
   },
   "group": {
     "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",
-    "@id": ("https://problemroulette.lsa.umich.edu/courses/" + (.courseIdNum|tostring)),
+    "@id": "https://problemroulette.lsa.umich.edu/courses/\(.courseIdNum)",
     "@type": "http://purl.imsglobal.org/caliper/v1/lis/CourseOffering",
     "name": .courseName,
   },
@@ -51,7 +51,7 @@
     "@type": "http://purl.imsglobal.org/caliper/v1/AssessmentItem",
     "isPartOf": {
       "@context": "http://purl.imsglobal.org/ctx/caliper/v1/Context",
-      "@id": ("https://problemroulette.lsa.umich.edu/courses/" + (.courseIdNum|tostring) + "/topics/" + (.topicIdNum|tostring)),
+      "@id": "https://problemroulette.lsa.umich.edu/courses/\(.courseIdNum)/topics/\(.topicIdNum)",
       "@type": "http://purl.imsglobal.org/caliper/v1/Assessment",
       "name": .topicName,
     },

--- a/src/reconcile/pr_jsonl.sql
+++ b/src/reconcile/pr_jsonl.sql
@@ -1,0 +1,58 @@
+SELECT
+  # Return JSONL (i.e., individual JSON objects, without commas in between)
+  json_object(
+      'action', CASE responses.answer
+                WHEN 0
+                  THEN 'Skipped'
+                ELSE 'Completed' END,
+      'actorAnswer', concat('', responses.answer), # String coercion
+      'actorUniqname', user.username,
+      'attemptCountNum', (
+        # Subquery: Count answers user gave before and including this one.
+        SELECT count(*)
+        FROM responses AS attempt_responses
+        WHERE
+          attempt_responses.prob_id = responses.prob_id AND
+          attempt_responses.user_id = responses.user_id AND
+          attempt_responses.end_time <= responses.end_time
+      ),
+      'correctAnswer', concat('', problems.correct), # String coercion
+      'courseIdNum', class.id,
+      'courseName', class.name,
+      'durationSeconds', concat(
+          'PT', timestampdiff(SECOND, start_time, end_time), 'S'), # ISO 8601 period
+      'endTime', date_format(convert_tz(responses.end_time, @@session.time_zone, '+00:00'),
+                             '%Y-%m-%dT%TZ'), # as GMT in ISO 8601
+      'isAnswerCorrect', CASE ans_correct
+                         WHEN 1
+                           THEN 'true'
+                         ELSE 'false' END, # Convert 0/1 to Boolean *string*
+      'problemName', problems.name,
+      'problemUrl', problems.url,
+      'startTime', date_format(convert_tz(responses.start_time, @@session.time_zone, '+00:00'),
+                               '%Y-%m-%dT%TZ'), # as GMT in ISO 8601
+      'topicIdNum', topic.id,
+      'topicName', topic.name
+  ) AS json
+FROM
+  responses
+  INNER JOIN problems ON responses.prob_id = problems.id
+  INNER JOIN topic ON responses.topic_id = topic.id
+  INNER JOIN `user` ON responses.user_id = `user`.id
+  INNER JOIN `12m_class_topic` ON responses.topic_id = `12m_class_topic`.topic_id
+  INNER JOIN class ON `12m_class_topic`.class_id = class.id
+WHERE
+  #   responses.end_time > '2016-06-26 00:00:00' # Caliper feature deployment date (EST)
+  #   AND `user`.id = 11447 AND problems.id = 942 # Helpful test criteria
+  #   AND
+  responses.end_time >= convert_tz(
+      '2016-10-19T02:22:06.383Z', '+00:00', @@session.time_zone
+  ) # Caliper feature interruption begins (from GMT in ISO 8601)
+  AND
+  responses.end_time <= convert_tz(
+      '2016-12-14T04:43:05.264Z', '+00:00', @@session.time_zone
+  ) # Caliper feature interruption ends (from GMT in ISO 8601)
+ORDER BY
+  responses.end_time ASC
+LIMIT
+  10

--- a/src/reconcile/pr_regenerate_caliper_events.sh
+++ b/src/reconcile/pr_regenerate_caliper_events.sh
@@ -1,0 +1,4 @@
+#!/bin/sh --
+
+# Send input on stdin or give the name of an input file as the first argument
+jq --compact-output --sort-keys --from-file pr_caliper_event_template.jq ${1:--}

--- a/src/reconcile/reduce.jq
+++ b/src/reconcile/reduce.jq
@@ -1,0 +1,15 @@
+def walk(f):
+  . as $in
+  | if type == "object" then
+      reduce keys_unsorted[] as $key
+        ( {}; . + { ($key):  ($in[$key] | walk(f)) } ) | f
+  elif type == "array" then map( walk(f) ) | f
+  else f
+  end;
+
+walk(
+  if type == "object" then with_entries(select(.value|length > 0))
+  elif type == "array" then map(select(length > 0))
+  else .
+  end
+)

--- a/src/reconcile/tsvDateAggregate.sh
+++ b/src/reconcile/tsvDateAggregate.sh
@@ -18,7 +18,7 @@ cut -d$'\t' -f1 dates_*.tsv | sort -u | sed 's/$/\t0/' > dates_all.tsv
 wc -l dates_all.tsv
 
 # add "0" to files that are missing dates
-for i in dates_*.tsv; do
+for i in dates_[mu]*.tsv; do
     name=$(basename $i .tsv)
     join -a1 -t$'\t' -e0 -o 0,2.2 dates_all.tsv $i > ${name}_withZeroes.tsv
 done


### PR DESCRIPTION
Given requirements for needed fields, create a bulk procedure to extract user action data from an application DB and create Caliper events en masse.

See:
* JIRA: https://itsjira.umms.med.umich.edu/browse/TLCALIPER-118
* Branch: https://github.com/lsloan/caliper-event-analysis/tree/TLCALIPER-118

Issue-specific Contents:
* `src/reconcile/pr_jsonl.sql`
  MySQL query to get all the necessary fields from the Problem Roulette DB for creating Caliper events.
* `src/reconcile/pr_caliper_event_template.jq`
  A jq template for a PR `AssessmentItemEvent`.
* `src/reconcile/pr_regenerate_caliper_events.sh`
  A shell script to execute jq, applying the above template to input on stdin or in a specified file.

The other files included in this PR are changes that aren't specific to this issue, but needed to be committed.
